### PR TITLE
fix/tiny-accessibility-fixes

### DIFF
--- a/src/modules/navigation/components/DrawerContent.tsx
+++ b/src/modules/navigation/components/DrawerContent.tsx
@@ -51,7 +51,7 @@ const DrawerContent = (props: DrawerContentComponentProps): JSX.Element => {
             key={`drawer-item-${key}`}
             label={() => generateItemLabels(key)}
             style={styles.headerItem}
-            pressColor={'black'}
+            pressColor={'white'}
             activeBackgroundColor={'#212121'}
             onPress={generateOnItemPressHandler({
               navigation: props.navigation,

--- a/src/modules/news/components/htmlStyles.ts
+++ b/src/modules/news/components/htmlStyles.ts
@@ -30,11 +30,11 @@ export const fullArticleTagStyles: Readonly<
   h3: { fontSize: 35, color: '#212121', fontWeight: '500' },
   p: {
     fontSize: 18,
-    marginBottom: '5%',
+    marginBottom: 18 * 2,
     color: '#212121',
     lineHeight: 18 * 1.5,
   },
-  a: { fontSize: 18, marginBottom: '5%', color: '#008629' },
+  a: { fontSize: 18, marginBottom: 18 * 2, color: '#008629' },
   figure: { marginBottom: 18 },
   figcaption: { fontSize: 16, color: '#555d66' },
 };


### PR DESCRIPTION
Paragraphs should now have empty space equal to 2 times line height after them. MenuItems are now whiter when navigated on to improve navigation visibility