### PR TITLE
removing query all packages permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.kouvolacityapp">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -34,5 +35,6 @@
         android:exported="true">
       </activity>
     </application>
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:node="remove" tools:ignore="QueryAllPackagesPermission" />
 </manifest>


### PR DESCRIPTION
Added configuration to AndroidManifest.xml for ignoring QUERY_ALL_PACKAGES permission requests during build