### PR TITLE
KM-36: fix padding issue in header menu icon with ios

### DIFF
--- a/src/modules/navigation/components/headers/styles.tsx
+++ b/src/modules/navigation/components/headers/styles.tsx
@@ -67,7 +67,7 @@ export default StyleSheet.create({
     marginLeft:'5%'
   },
   iconStyle: {
-    padding: Sizing.IP,
+    padding: Platform.OS === "android" ? Sizing.IP : 0,
     fontSize: 30,
   },
   backbtnStyle: {


### PR DESCRIPTION
added platform-specific padding for "burger menu" icon in header,  since the headers are different size on android and ios

https://punosmobile.atlassian.net/jira/software/projects/KM/boards/4?selectedIssue=KM-36