### PR TITLE
KM-39: set max brightness when using library card

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -375,6 +375,8 @@ PODS:
   - React-jsinspector (0.72.3)
   - React-logger (0.72.3):
     - glog
+  - react-native-device-brightness (1.2.7):
+    - React
   - react-native-render-html (6.3.4):
     - React-Core
   - react-native-safe-area-context (4.7.1):
@@ -503,35 +505,10 @@ PODS:
     - React-Core
   - RNLocalize (3.0.2):
     - React-Core
-  - RNReanimated (3.4.1):
-    - DoubleConversion
-    - FBLazyVector
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-callinvoker
+  - RNReanimated (3.7.1):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-    - React-Core/DevSupport
-    - React-Core/RCTWebSocket
-    - React-CoreModules
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-RCTActionSheet
-    - React-RCTAnimation
-    - React-RCTAppDelegate
-    - React-RCTBlob
-    - React-RCTImage
-    - React-RCTLinking
-    - React-RCTNetwork
-    - React-RCTSettings
-    - React-RCTText
     - ReactCommon/turbomodule/core
-    - Yoga
   - RNScreens (3.23.0):
     - React-Core
     - React-RCTImage
@@ -592,6 +569,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-device-brightness (from `../node_modules/@adrianso/react-native-device-brightness`)"
   - react-native-render-html (from `../node_modules/react-native-render-html`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
@@ -686,6 +664,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-device-brightness:
+    :path: "../node_modules/@adrianso/react-native-device-brightness"
   react-native-render-html:
     :path: "../node_modules/react-native-render-html"
   react-native-safe-area-context:
@@ -785,6 +765,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 59d1eb03af7d30b7d66589c410f13151271e8006
   React-jsinspector: b511447170f561157547bc0bef3f169663860be7
   React-logger: c5b527272d5f22eaa09bb3c3a690fee8f237ae95
+  react-native-device-brightness: 886cfbfb49a32b6de4ccfc1f720776dc5f381d24
   react-native-render-html: 984dfe2294163d04bf5fe25d7c9f122e60e05ebe
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
@@ -811,7 +792,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNLocalize: dbea38dcb344bf80ff18a1757b1becf11f70cae4
-  RNReanimated: 53ca20eee770c41173703f5948cd8898aa08262c
+  RNReanimated: 43675f1f0e704abe8ebf953fd79b00e66302cda2
   RNScreens: 6a8a3c6b808aa48dca1780df7b73ea524f602c63
   RNSVG: 80584470ff1ffc7994923ea135a3e5ad825546b9
   RNVectorIcons: 8b5bb0fa61d54cd2020af4f24a51841ce365c7e9

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@react-navigation/stack": "6.3.17",
         "@rneui/base": "^4.0.0-rc.7",
         "@rneui/themed": "^4.0.0-rc.7",
-        "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git#chore/screen-brightness-library-card",
+        "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git",
         "OpenCityKvlModules": "git+https://github.com/City-of-Kouvola/open-city-kvl-modules.git",
         "react": "18.2.0",
         "react-native": "0.72.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "KouvolaCityApp",
       "version": "1.9.2",
       "dependencies": {
+        "@adrianso/react-native-device-brightness": "^1.2.7",
         "@react-native-async-storage/async-storage": "1.19.1",
         "@react-native-community/art": "^1.2.0",
         "@react-native-community/toolbar-android": "^0.2.1",
@@ -16,7 +17,7 @@
         "@react-navigation/stack": "6.3.17",
         "@rneui/base": "^4.0.0-rc.7",
         "@rneui/themed": "^4.0.0-rc.7",
-        "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git",
+        "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git#chore/screen-brightness-library-card",
         "OpenCityKvlModules": "git+https://github.com/City-of-Kouvola/open-city-kvl-modules.git",
         "react": "18.2.0",
         "react-native": "0.72.3",
@@ -63,6 +64,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adrianso/react-native-device-brightness": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@adrianso/react-native-device-brightness/-/react-native-device-brightness-1.2.7.tgz",
+      "integrity": "sha512-q3OTFGohAh04R8cBka7/eNXaeSD8bAZocMsifLIR3oDF5N9cNH2UVEjzJaFXW8DHFEsODpljpT+eyGWIhKlkow=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@react-navigation/stack": "6.3.17",
     "@rneui/base": "^4.0.0-rc.7",
     "@rneui/themed": "^4.0.0-rc.7",
-    "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git#chore\/screen-brightness-library-card",
+    "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git",
     "OpenCityKvlModules": "git+https://github.com/City-of-Kouvola/open-city-kvl-modules.git",
     "react": "18.2.0",
     "react-native": "0.72.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@adrianso/react-native-device-brightness": "^1.2.7",
     "@react-native-async-storage/async-storage": "1.19.1",
     "@react-native-community/art": "^1.2.0",
     "@react-native-community/toolbar-android": "^0.2.1",
@@ -17,7 +18,7 @@
     "@react-navigation/stack": "6.3.17",
     "@rneui/base": "^4.0.0-rc.7",
     "@rneui/themed": "^4.0.0-rc.7",
-    "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git",
+    "library_card_module": "git+https://github.com/City-of-Kouvola/Library_card_module.git#chore\/screen-brightness-library-card",
     "OpenCityKvlModules": "git+https://github.com/City-of-Kouvola/open-city-kvl-modules.git",
     "react": "18.2.0",
     "react-native": "0.72.3",

--- a/src/modules/navigation/LibraryCardStack/LibraryCardStack.tsx
+++ b/src/modules/navigation/LibraryCardStack/LibraryCardStack.tsx
@@ -4,18 +4,26 @@ import { createStackNavigator } from '@react-navigation/stack';
 
 import { generateCommonStackOptions } from '../helpers';
 import { ERouteName } from '../typings';
+import { useIsFocused } from '@react-navigation/native';
 
 const Stack = createStackNavigator();
 
 export default function LibraryCardStack() {
+
+  const LibraryCardWrapper = () => {
+    const isFocused = useIsFocused();
+    return <LibraryCardModule isFocused={isFocused} />
+  }
+
   return (
     <Stack.Navigator
       screenOptions={{ ...generateCommonStackOptions() }}
       initialRouteName={ERouteName.LIBRARY_CARD_INITIAL}>
       <Stack.Screen
         name={ERouteName.LIBRARY_CARD_INITIAL}
-        component={LibraryCardModule}
+        component={LibraryCardWrapper}
       />
     </Stack.Navigator>
   );
+  
 }


### PR DESCRIPTION
- added a wrapper component for the library card module for using the isFocused field correctly

- to test, change library card module path to this: 
`"library_card_module": "github:City-of-Kouvola/Library_card_module#chore\/screen-brightness-library-card",`
- `library_card_module` pull request of this feature: https://github.com/City-of-Kouvola/Library_card_module/pull/28 